### PR TITLE
add use auth token; update readme and message method to use match_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pyro.like(user_id)
 pyro.dislike(user_id)
 
 # Send a saucy message
-pyro.send_message(user_id, 'I luv u plz b my friend')
+pyro.send_message(match_id, 'I luv u plz b my friend')
 ```
 
 **Interacting with yourself**

--- a/lib/pyro/client.rb
+++ b/lib/pyro/client.rb
@@ -31,9 +31,9 @@ module TinderPyro
       @requestor.get_request(:profile)
     end
 
-    def send_message(user_id, message)
+    def send_message(match_id, message)
       @requestor.post_request(
-        "user/matches/#{user_id}",
+        "user/matches/#{match_id}",
         message: message
       )
     end
@@ -44,6 +44,10 @@ module TinderPyro
 
     def update_location(latitude, longitude)
       @requestor.post_request("user/ping", lat: latitude, lon: longitude)
+    end
+
+    def use_auth_token(token)
+      @requestor.auth_token = token
     end
   end
 end

--- a/lib/pyro/requestor.rb
+++ b/lib/pyro/requestor.rb
@@ -2,6 +2,8 @@ module TinderPyro
   class Requestor
     include HTTParty
 
+    attr_accessor :auth_token
+
     base_uri 'https://api.gotinder.com'
 
     def auth_request(facebook_id, facebook_token)


### PR DESCRIPTION
re: auth token

you can persist the tinder token and keep using it without having to go through the facebook oauth.